### PR TITLE
Fix exchange.getPrincipal()

### DIFF
--- a/src/main/java/com/example/issue144/Issue144Application.java
+++ b/src/main/java/com/example/issue144/Issue144Application.java
@@ -48,10 +48,13 @@ public class Issue144Application {
                 .route("httpbin", r -> r
                         .order(8000)
                         .path("/**")
-                        .filter((exchange, chain) -> {
-                            exchange.getPrincipal().switchIfEmpty(Mono.just(() -> "empty")).subscribe(p -> log.info("principal.name: {}", p.getName()));
-                            return chain.filter(exchange);
-                        })
+                        .filter((exchange, chain) ->
+                            exchange
+                                    .getPrincipal()
+                                    .switchIfEmpty(Mono.just(() -> "empty"))
+                                    .doOnSuccess(p -> log.info("principal.name: {}", p.getName()))
+                                    .then(chain.filter(exchange))
+                        )
                         .uri("http://httpbin.org:80")
                 )
                 .build();


### PR DESCRIPTION
For getPrincipal() to work, it must be part of the Reactor pipeline. This
means it must be part of a value that is returned up through the
WebFilterChain.

This is a restriction on how Reactor's Context (which is what backs
Spring Security's Reactive user storage) works. See
http://projectreactor.io/docs/core/release/reference/#context